### PR TITLE
1.0.3 - Supporting older .NET versions

### DIFF
--- a/Rejigs/Rejigs.cs
+++ b/Rejigs/Rejigs.cs
@@ -20,9 +20,7 @@ public class Rejigs
     public Rejigs Text(string text)
     {
         // Special-case: if text is empty, match only the empty string
-        if (text == "")
-            return Append("^$");
-        return Append(Regex.Escape(text));
+        return Append(text == "" ? "^$" : Regex.Escape(text));
     }
 
     /// <summary>

--- a/Rejigs/Rejigs.csproj
+++ b/Rejigs/Rejigs.csproj
@@ -1,9 +1,9 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net9.0</TargetFramework>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
+        <TargetFrameworks>net6.0;net7.0;net8.0;net9.0</TargetFrameworks>
     </PropertyGroup>
     
     <PropertyGroup>

--- a/Rejigs/Rejigs.csproj
+++ b/Rejigs/Rejigs.csproj
@@ -9,7 +9,7 @@
     <PropertyGroup>
         <PackageId>Rejigs</PackageId>
         <Authors>omarzawahry</Authors>
-        <Version>1.0.2</Version>
+        <Version>1.0.3</Version>
         <Description>A fluent interface for building regular expressions</Description>
         <PackageTags>regex;regular-expressions;fluent</PackageTags>
         <PackageLicenseExpression>MIT</PackageLicenseExpression>


### PR DESCRIPTION
This pull request includes a minor refactor to simplify a method in `Rejigs.cs` and updates the project file `Rejigs.csproj` to support multiple target frameworks and increment the package version.

Code refactoring:

* Simplified the `Text` method in `Rejigs` by replacing an `if` statement with a ternary operator for better readability and conciseness. (`Rejigs/Rejigs.cs`, [Rejigs/Rejigs.csL23-R23](diffhunk://#diff-9d4767fb58ce9cb3c769b4e82d3d708d62a520a9fad9547ce15767ae512aadfdL23-R23))

Project updates:

* Updated `Rejigs.csproj` to support multiple target frameworks (`net6.0`, `net7.0`, `net8.0`, and `net9.0`) instead of just `net9.0`. (`Rejigs/Rejigs.csproj`, [Rejigs/Rejigs.csprojL4-R12](diffhunk://#diff-1da7d6abf07120de5d0248deacafe1ec71691be9b69ab41eabbd718e23e70360L4-R12))
* Incremented the package version from `1.0.2` to `1.0.3` to reflect the changes. (`Rejigs/Rejigs.csproj`, [Rejigs/Rejigs.csprojL4-R12](diffhunk://#diff-1da7d6abf07120de5d0248deacafe1ec71691be9b69ab41eabbd718e23e70360L4-R12))