### PR TITLE
1.0.5 - Adding support to multiple .NET versions

### DIFF
--- a/Rejigs/Rejigs.csproj
+++ b/Rejigs/Rejigs.csproj
@@ -9,7 +9,7 @@
     <PropertyGroup>
         <PackageId>Rejigs</PackageId>
         <Authors>omarzawahry</Authors>
-        <Version>1.0.4</Version>
+        <Version>1.0.5</Version>
         <Description>A fluent interface for building regular expressions</Description>
         <PackageTags>regex;regular-expressions;fluent</PackageTags>
         <PackageLicenseExpression>MIT</PackageLicenseExpression>

--- a/Rejigs/Rejigs.csproj
+++ b/Rejigs/Rejigs.csproj
@@ -3,7 +3,7 @@
     <PropertyGroup>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
-        <TargetFramework>net9.0</TargetFramework>
+        <TargetFrameworks>net9.0;net6.0;net7.0;net8.0</TargetFrameworks>
     </PropertyGroup>
     
     <PropertyGroup>


### PR DESCRIPTION
This pull request updates the `Rejigs.csproj` file to expand framework support and increment the package version.

Framework support updates:

* Changed the `TargetFramework` property to `TargetFrameworks`, adding support for multiple .NET versions: `net6.0`, `net7.0`, and `net8.0`, in addition to `net9.0`.

Versioning update:

* Incremented the package version from `1.0.4` to `1.0.5` to reflect the changes.