### PR TITLE
Refine email regex pattern and update test

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,8 @@ var emailRegex = Rejigs.Create()
                        .Text("@")
                        .OneOrMore(r => r.AnyLetterOrDigit().Or().AnyOf(".-"))   // Domain
                        .Text(".")
-                       .Between(2, 6).AnyInRange('a', 'z') // Top-level domain (2-6 letters)
+                       .AnyInRange('a', 'z') // Top-level domain (2-6 letters)
+                       .Between(2, 6)
                        .AtEnd()
                        .IgnoreCase() // Case-insensitive matching
                        .Build();

--- a/Rejigs.Tests/ComplexPatterns.cs
+++ b/Rejigs.Tests/ComplexPatterns.cs
@@ -9,17 +9,19 @@ public class ComplexPatterns
     {
         var regex = Rejigs.Create()
                           .AtStart()
-                          .OneOrMore(r => r.AnyLetterOrDigit().Or().AnyOf(".-"))
+                          .OneOrMore(r => r.AnyLetterOrDigit().Or().AnyOf(".-_"))
                           .Text("@")
                           .OneOrMore(r => r.AnyLetterOrDigit().Or().AnyOf(".-"))
                           .Text(".")
-                          .AnyLetterOrDigit()
-                          .AtLeast(2)
+                          .AnyInRange('a', 'z')
+                          .Between(2, 6)
                           .AtEnd()
+                          .IgnoreCase()
                           .Build();
 
         Assert.That("user@example.com", Does.Match(regex));
         Assert.That("user.name@example.co.uk", Does.Match(regex));
+        Assert.That("user.name@example.comaqwr", Does.Not.Match(regex));
         Assert.That("user@com", Does.Not.Match(regex));
         Assert.That("@example.com", Does.Not.Match(regex));
     }


### PR DESCRIPTION
Adjusted the email regex in both README and ComplexPatterns test to correctly apply the top-level domain length constraint and case-insensitive matching. The test now matches the documented pattern, improving consistency and accuracy.