### PR TITLE
Refactor tests to use parameterized TestCase attributes

### DIFF
--- a/Rejigs.Tests/AlterationsTests.cs
+++ b/Rejigs.Tests/AlterationsTests.cs
@@ -4,8 +4,11 @@ namespace Rejigs.Tests;
 
 public class AlterationsTests
 {
-    [Test]
-    public void Either_MatchesAlternatives()
+    [TestCase("cat", true)]
+    [TestCase("dog", true)]
+    [TestCase("mouse", true)]
+    [TestCase("hamster", false)]
+    public void Either_MatchesAlternatives(string input, bool shouldMatch)
     {
         var regex = Rejigs.Create()
                           .Either(
@@ -14,14 +17,16 @@ public class AlterationsTests
                               r => r.Text("mouse")
                           ).Build();
 
-        Assert.That("cat", Does.Match(regex));
-        Assert.That("dog", Does.Match(regex));
-        Assert.That("mouse", Does.Match(regex));
-        Assert.That("hamster", Does.Not.Match(regex));
+        if (shouldMatch)
+            Assert.That(input, Does.Match(regex));
+        else
+            Assert.That(input, Does.Not.Match(regex));
     }
 
-    [Test]
-    public void Or_MatchesAlternatives()
+    [TestCase("cat", true)]
+    [TestCase("dog", true)]
+    [TestCase("catdog", true)]
+    public void Or_MatchesAlternatives(string input, bool shouldMatch)
     {
         var regex = Rejigs.Create()
                           .Text("cat")
@@ -29,8 +34,9 @@ public class AlterationsTests
                           .Text("dog")
                           .Build();
 
-        Assert.That("cat", Does.Match(regex));
-        Assert.That("dog", Does.Match(regex));
-        Assert.That("catdog", Does.Match(regex));
+        if (shouldMatch)
+            Assert.That(input, Does.Match(regex));
+        else
+            Assert.That(input, Does.Not.Match(regex));
     }
 }

--- a/Rejigs.Tests/AnchorsTests.cs
+++ b/Rejigs.Tests/AnchorsTests.cs
@@ -4,38 +4,54 @@ namespace Rejigs.Tests;
 
 public class AnchorsTests
 {
-    [Test]
-    public void AtStart_AnchorsBeginingOfLine()
+    [TestCase("abc", true)]
+    [TestCase("abcdef", true)]
+    [TestCase("xabc", false)]
+    public void AtStart_AnchorsBeginingOfLine(string input, bool shouldMatch)
     {
         var regex = Rejigs.Create().AtStart().Text("abc").Build();
-        Assert.That("abc", Does.Match(regex));
-        Assert.That("abcdef", Does.Match(regex));
-        Assert.That("xabc", Does.Not.Match(regex));
+        
+        if (shouldMatch)
+            Assert.That(input, Does.Match(regex));
+        else
+            Assert.That(input, Does.Not.Match(regex));
     }
 
-    [Test]
-    public void AtEnd_AnchorsEndOfLine()
+    [TestCase("abc", true)]
+    [TestCase("xabc", true)]
+    [TestCase("abcx", false)]
+    public void AtEnd_AnchorsEndOfLine(string input, bool shouldMatch)
     {
         var regex = Rejigs.Create().Text("abc").AtEnd().Build();
-        Assert.That("abc", Does.Match(regex));
-        Assert.That("xabc", Does.Match(regex));
-        Assert.That("abcx", Does.Not.Match(regex));
+        
+        if (shouldMatch)
+            Assert.That(input, Does.Match(regex));
+        else
+            Assert.That(input, Does.Not.Match(regex));
     }
 
-    [Test]
-    public void AtWordBoundary_MatchesAtWordBoundary()
+    [TestCase("cat", true)]
+    [TestCase("the cat", true)]
+    [TestCase("tomcat", false)]
+    public void AtWordBoundary_MatchesAtWordBoundary(string input, bool shouldMatch)
     {
         var regex = Rejigs.Create().AtWordBoundary().Text("cat").Build();
-        Assert.That("cat", Does.Match(regex));
-        Assert.That("the cat", Does.Match(regex));
-        Assert.That("tomcat", Does.Not.Match(regex));
+        
+        if (shouldMatch)
+            Assert.That(input, Does.Match(regex));
+        else
+            Assert.That(input, Does.Not.Match(regex));
     }
 
-    [Test]
-    public void NotAtWordBoundary_MatchesNotAtWordBoundary()
+    [TestCase("tomcat", true)]
+    [TestCase("cat", false)]
+    public void NotAtWordBoundary_MatchesNotAtWordBoundary(string input, bool shouldMatch)
     {
         var regex = Rejigs.Create().NotAtWordBoundary().Text("cat").Build();
-        Assert.That("tomcat", Does.Match(regex));
-        Assert.That("cat", Does.Not.Match(regex));
+        
+        if (shouldMatch)
+            Assert.That(input, Does.Match(regex));
+        else
+            Assert.That(input, Does.Not.Match(regex));
     }
 }

--- a/Rejigs.Tests/CharactersTests.cs
+++ b/Rejigs.Tests/CharactersTests.cs
@@ -4,108 +4,139 @@ namespace Rejigs.Tests;
 
 public class Character
 {
-    [Test]
-        public void AnyDigit_MatchesSingleDigit()
-        {
-            var regex = Rejigs.Create().AnyDigit().Build();
-            
-            Assert.That("5", Does.Match(regex));
-            Assert.That("a", Does.Not.Match(regex));
-        }
+    [TestCase("5", true)]
+    [TestCase("a", false)]
+    public void AnyDigit_MatchesSingleDigit(string input, bool shouldMatch)
+    {
+        var regex = Rejigs.Create().AnyDigit().Build();
+        
+        if (shouldMatch)
+            Assert.That(input, Does.Match(regex));
+        else
+            Assert.That(input, Does.Not.Match(regex));
+    }
 
-        [Test]
-        public void AnyNonDigit_MatchesSingleNonDigit()
-        {
-            var regex = Rejigs.Create().AnyNonDigit().Build();
-            
-            Assert.That("a", Does.Match(regex));
-            Assert.That("_", Does.Match(regex));
-            Assert.That("$", Does.Match(regex));
-            Assert.That("5", Does.Not.Match(regex));
-        }
+    [TestCase("a", true)]
+    [TestCase("_", true)]
+    [TestCase("$", true)]
+    [TestCase("5", false)]
+    public void AnyNonDigit_MatchesSingleNonDigit(string input, bool shouldMatch)
+    {
+        var regex = Rejigs.Create().AnyNonDigit().Build();
+        
+        if (shouldMatch)
+            Assert.That(input, Does.Match(regex));
+        else
+            Assert.That(input, Does.Not.Match(regex));
+    }
 
-        [Test]
-        public void AnyLetterOrDigit_MatchesWordCharacter()
-        {
-            var regex = Rejigs.Create().AnyLetterOrDigit().Build();
-            
-            Assert.That("a", Does.Match(regex));
-            Assert.That("_", Does.Match(regex));
-            Assert.That("1", Does.Match(regex));
-            Assert.That("$", Does.Not.Match(regex));
-        }
+    [TestCase("a", true)]
+    [TestCase("_", true)]
+    [TestCase("1", true)]
+    [TestCase("$", false)]
+    public void AnyLetterOrDigit_MatchesWordCharacter(string input, bool shouldMatch)
+    {
+        var regex = Rejigs.Create().AnyLetterOrDigit().Build();
+        
+        if (shouldMatch)
+            Assert.That(input, Does.Match(regex));
+        else
+            Assert.That(input, Does.Not.Match(regex));
+    }
 
-        [Test]
-        public void AnyNonLetterOrDigit_MatchesNonWordCharacter()
-        {
-            var regex = Rejigs.Create().AnyNonLetterOrDigit().Build();
-            Assert.That("$", Does.Match(regex));
-            Assert.That("a", Does.Not.Match(regex));
-            Assert.That("1", Does.Not.Match(regex));
-        }
+    [TestCase("$", true)]
+    [TestCase("a", false)]
+    [TestCase("1", false)]
+    public void AnyNonLetterOrDigit_MatchesNonWordCharacter(string input, bool shouldMatch)
+    {
+        var regex = Rejigs.Create().AnyNonLetterOrDigit().Build();
+        
+        if (shouldMatch)
+            Assert.That(input, Does.Match(regex));
+        else
+            Assert.That(input, Does.Not.Match(regex));
+    }
 
-        [Test]
-        public void AnySpace_MatchesWhitespace()
-        {
-            var regex = Rejigs.Create().AnySpace().Build();
-            
-            Assert.That(" ", Does.Match(regex));
-            Assert.That("\t", Does.Match(regex));
-            Assert.That("a", Does.Not.Match(regex));
-        }
+    [TestCase(" ", true)]
+    [TestCase("\t", true)]
+    [TestCase("a", false)]
+    public void AnySpace_MatchesWhitespace(string input, bool shouldMatch)
+    {
+        var regex = Rejigs.Create().AnySpace().Build();
+        
+        if (shouldMatch)
+            Assert.That(input, Does.Match(regex));
+        else
+            Assert.That(input, Does.Not.Match(regex));
+    }
 
-        [Test]
-        public void AnyNonSpace_MatchesNonWhitespace()
-        {
-            var regex = Rejigs.Create().AnyNonSpace().Build();
-            
-            Assert.That("a", Does.Match(regex));
-            Assert.That(" ", Does.Not.Match(regex));
-            Assert.That("\t", Does.Not.Match(regex));
-        }
+    [TestCase("a", true)]
+    [TestCase(" ", false)]
+    [TestCase("\t", false)]
+    public void AnyNonSpace_MatchesNonWhitespace(string input, bool shouldMatch)
+    {
+        var regex = Rejigs.Create().AnyNonSpace().Build();
+        
+        if (shouldMatch)
+            Assert.That(input, Does.Match(regex));
+        else
+            Assert.That(input, Does.Not.Match(regex));
+    }
 
-        [Test]
-        public void AnyCharacter_MatchesAnyCharacter()
-        {
-            var regex = Rejigs.Create().AnyCharacter().Build();
-            
-            Assert.That("a", Does.Match(regex));
-            Assert.That("1", Does.Match(regex));
-            Assert.That("$", Does.Match(regex));
-            Assert.That("\n", Does.Not.Match(regex));
-        }
+    [TestCase("a", true)]
+    [TestCase("1", true)]
+    [TestCase("$", true)]
+    [TestCase("\n", false)]
+    public void AnyCharacter_MatchesAnyCharacter(string input, bool shouldMatch)
+    {
+        var regex = Rejigs.Create().AnyCharacter().Build();
+        
+        if (shouldMatch)
+            Assert.That(input, Does.Match(regex));
+        else
+            Assert.That(input, Does.Not.Match(regex));
+    }
 
-        [Test]
-        public void AnyOf_MatchesCharactersInSet()
-        {
-            var regex = Rejigs.Create().AnyOf("abc").Build();
-            
-            Assert.That("a", Does.Match(regex));
-            Assert.That("b", Does.Match(regex));
-            Assert.That("c", Does.Match(regex));
-            Assert.That("z", Does.Not.Match(regex));
-        }
+    [TestCase("a", true)]
+    [TestCase("b", true)]
+    [TestCase("c", true)]
+    [TestCase("z", false)]
+    public void AnyOf_MatchesCharactersInSet(string input, bool shouldMatch)
+    {
+        var regex = Rejigs.Create().AnyOf("abc").Build();
+        
+        if (shouldMatch)
+            Assert.That(input, Does.Match(regex));
+        else
+            Assert.That(input, Does.Not.Match(regex));
+    }
 
-        [Test]
-        public void AnyInRange_MatchesCharactersInRange()
-        {
-            var regex = Rejigs.Create().AnyInRange('a', 'f').Build();
-            
-            Assert.That("a", Does.Match(regex));
-            Assert.That("d", Does.Match(regex));
-            Assert.That("f", Does.Match(regex));
-            Assert.That("af", Does.Match(regex));
-            Assert.That("g", Does.Not.Match(regex));
-        }
+    [TestCase("a", true)]
+    [TestCase("d", true)]
+    [TestCase("f", true)]
+    [TestCase("af", true)]
+    [TestCase("g", false)]
+    public void AnyInRange_MatchesCharactersInRange(string input, bool shouldMatch)
+    {
+        var regex = Rejigs.Create().AnyInRange('a', 'f').Build();
+        
+        if (shouldMatch)
+            Assert.That(input, Does.Match(regex));
+        else
+            Assert.That(input, Does.Not.Match(regex));
+    }
 
-        [Test]
-        public void AnyExcept_MatchesCharactersNotInSet()
-        {
-            var regex = Rejigs.Create().AnyExcept("xyz").Build();
-            
-            Assert.That("a", Does.Match(regex));
-            Assert.That("aq", Does.Match(regex));
-            Assert.That("x", Does.Not.Match(regex));
-            Assert.That("y", Does.Not.Match(regex));
-        }
+    [TestCase("a", true)]
+    [TestCase("aq", true)]
+    [TestCase("x", false)]
+    [TestCase("y", false)]
+    public void AnyExcept_MatchesCharactersNotInSet(string input, bool shouldMatch)
+    {
+        var regex = Rejigs.Create().AnyExcept("xyz").Build();
+        
+        if (shouldMatch)
+            Assert.That(input, Does.Match(regex));
+        else
+            Assert.That(input, Does.Not.Match(regex));
+    }
 }

--- a/Rejigs.Tests/ComplexPatterns.cs
+++ b/Rejigs.Tests/ComplexPatterns.cs
@@ -4,8 +4,12 @@ namespace Rejigs.Tests;
 
 public class ComplexPatterns
 {
-    [Test]
-    public void ValidatesEmailAddress()
+    [TestCase("user@example.com", true)]
+    [TestCase("user.name@example.co.uk", true)]
+    [TestCase("user.name@example.comaqwr", false)]
+    [TestCase("user@com", false)]
+    [TestCase("@example.com", false)]
+    public void ValidatesEmailAddress(string input, bool shouldMatch)
     {
         var regex = Rejigs.Create()
                           .AtStart()
@@ -19,15 +23,17 @@ public class ComplexPatterns
                           .IgnoreCase()
                           .Build();
 
-        Assert.That("user@example.com", Does.Match(regex));
-        Assert.That("user.name@example.co.uk", Does.Match(regex));
-        Assert.That("user.name@example.comaqwr", Does.Not.Match(regex));
-        Assert.That("user@com", Does.Not.Match(regex));
-        Assert.That("@example.com", Does.Not.Match(regex));
+        if (shouldMatch)
+            Assert.That(input, Does.Match(regex));
+        else
+            Assert.That(input, Does.Not.Match(regex));
     }
 
-    [Test]
-    public void ValidatesPhoneNumber()
+    [TestCase("123-456-7890", true)]
+    [TestCase("1234567890", true)]
+    [TestCase("+1-123-456-7890", true)]
+    [TestCase("abc-def-ghij", false)]
+    public void ValidatesPhoneNumber(string input, bool shouldMatch)
     {
         var regex = Rejigs.Create()
                           .Optional(r => r.Text("+"))
@@ -39,14 +45,18 @@ public class ComplexPatterns
                           .Grouping(r => r.AnyDigit().Exactly(4))
                           .Build();
 
-        Assert.That("123-456-7890", Does.Match(regex));
-        Assert.That("1234567890", Does.Match(regex));
-        Assert.That("+1-123-456-7890", Does.Match(regex));
-        Assert.That("abc-def-ghij", Does.Not.Match(regex));
+        if (shouldMatch)
+            Assert.That(input, Does.Match(regex));
+        else
+            Assert.That(input, Does.Not.Match(regex));
     }
 
-    [Test]
-    public void ValidatesISODate()
+    [TestCase("2023-01-01", true)]
+    [TestCase("2023-12-31", true)]
+    [TestCase("2023-13-01", false)]
+    [TestCase("2023-12-32", false)]
+    [TestCase("23-01-01", false)]
+    public void ValidatesISODate(string input, bool shouldMatch)
     {
         var regex = Rejigs.Create()
                           .AtStart()
@@ -68,15 +78,18 @@ public class ComplexPatterns
                           .AtEnd()
                           .Build();
 
-        Assert.That("2023-01-01", Does.Match(regex));
-        Assert.That("2023-12-31", Does.Match(regex));
-        Assert.That("2023-13-01", Does.Not.Match(regex));
-        Assert.That("2023-12-32", Does.Not.Match(regex));
-        Assert.That("23-01-01", Does.Not.Match(regex));
+        if (shouldMatch)
+            Assert.That(input, Does.Match(regex));
+        else
+            Assert.That(input, Does.Not.Match(regex));
     }
 
-    [Test]
-    public void ValidatesIPv4Address()
+    [TestCase("192.168.0.1", true)]
+    [TestCase("127.0.0.1", true)]
+    [TestCase("255.255.255.255", true)]
+    [TestCase("256.0.0.1", false)]
+    [TestCase("192.168.0", false)]
+    public void ValidatesIPv4Address(string input, bool shouldMatch)
     {
         var octet = Rejigs.Create()
                           .Either(
@@ -101,10 +114,9 @@ public class ComplexPatterns
                           .AtEnd()
                           .Build();
 
-        Assert.That("192.168.0.1", Does.Match(regex));
-        Assert.That("127.0.0.1", Does.Match(regex));
-        Assert.That("255.255.255.255", Does.Match(regex));
-        Assert.That("256.0.0.1", Does.Not.Match(regex));
-        Assert.That("192.168.0", Does.Not.Match(regex));
+        if (shouldMatch)
+            Assert.That(input, Does.Match(regex));
+        else
+            Assert.That(input, Does.Not.Match(regex));
     }
 }

--- a/Rejigs.Tests/GroupingTests.cs
+++ b/Rejigs.Tests/GroupingTests.cs
@@ -4,15 +4,18 @@ namespace Rejigs.Tests;
 
 public class GroupingTests
 {
-    [Test]
-    public void Grouping_WithQuantifier()
+    [TestCase("abcabc", true)]
+    [TestCase("abc", false)]
+    public void Grouping_WithQuantifier(string input, bool shouldMatch)
     {
         var regex = Rejigs.Create()
                           .Grouping(r => r.Text("abc"))
                           .Exactly(2)
                           .Build();
 
-        Assert.That("abcabc", Does.Match(regex));
-        Assert.That("abc", Does.Not.Match(regex));
+        if (shouldMatch)
+            Assert.That(input, Does.Match(regex));
+        else
+            Assert.That(input, Does.Not.Match(regex));
     }
 }

--- a/Rejigs.Tests/LiteralTests.cs
+++ b/Rejigs.Tests/LiteralTests.cs
@@ -4,43 +4,55 @@ namespace Rejigs.Tests;
 
 public class LiteralTests
 {
-    [Test]
-    public void Text_MatchesExactText()
+    [TestCase("hello", true)]
+    [TestCase("Hello", false)]
+    public void Text_MatchesExactText(string input, bool shouldMatch)
     {
         var regex = Rejigs.Create().Text("hello").Build();
         
-        Assert.That("hello", Does.Match(regex));
-        Assert.That("Hello", Does.Not.Match(regex));
+        if (shouldMatch)
+            Assert.That(input, Does.Match(regex));
+        else
+            Assert.That(input, Does.Not.Match(regex));
     }
 
-    [Test]
-    public void Text_EscapesSpecialCharacters()
+    [TestCase("a.b*c+", true)]
+    [TestCase("abc", false)]
+    public void Text_EscapesSpecialCharacters(string input, bool shouldMatch)
     {
         var regex = Rejigs.Create().Text("a.b*c+").Build();
         
-        Assert.That("a.b*c+", Does.Match(regex));
-        Assert.That("abc", Does.Not.Match(regex));
+        if (shouldMatch)
+            Assert.That(input, Does.Match(regex));
+        else
+            Assert.That(input, Does.Not.Match(regex));
     }
 
-    [Test]
-    public void Text_EmptyString_MatchesOnlyEmptyString()
+    [TestCase("", true)]
+    [TestCase("a", false)]
+    [TestCase("b", false)]
+    [TestCase("     ", false)]
+    public void Text_EmptyString_MatchesOnlyEmptyString(string input, bool shouldMatch)
     {
         var regex = Rejigs.Create().Text("").Build();
         
-        Assert.That("", Does.Match(regex));
-        Assert.That("a", Does.Not.Match(regex));
-        Assert.That("b", Does.Not.Match(regex));
-        Assert.That("     ", Does.Not.Match(regex));
+        if (shouldMatch)
+            Assert.That(input, Does.Match(regex));
+        else
+            Assert.That(input, Does.Not.Match(regex));
     }
 
-    [Test]
-    public void Text_Whitespace_MatchesExactWhitespace()
+    [TestCase(" \t\n", true)]
+    [TestCase(" ", false)]
+    [TestCase("     \n", false)]
+    public void Text_Whitespace_MatchesExactWhitespace(string input, bool shouldMatch)
     {
         var regex = Rejigs.Create().Text(" \t\n").Build();
         
-        Assert.That(" \t\n", Does.Match(regex));
-        Assert.That(" ", Does.Not.Match(regex));
-        Assert.That("     \n", Does.Not.Match(regex));
+        if (shouldMatch)
+            Assert.That(input, Does.Match(regex));
+        else
+            Assert.That(input, Does.Not.Match(regex));
     }
 
     [Test]
@@ -53,37 +65,48 @@ public class LiteralTests
         Assert.That(".", Does.Not.Match(regex));
     }
 
-    [Test]
-    public void Text_UnicodeCharacters_MatchExactly()
+    [TestCase("こんにちは世界", true)]
+    [TestCase("こんにちは", false)]
+    public void Text_UnicodeCharacters_MatchExactly(string input, bool shouldMatch)
     {
         var regex = Rejigs.Create().Text("こんにちは世界").Build();
         
-        Assert.That("こんにちは世界", Does.Match(regex));
-        Assert.That("こんにちは", Does.Not.Match(regex));
+        if (shouldMatch)
+            Assert.That(input, Does.Match(regex));
+        else
+            Assert.That(input, Does.Not.Match(regex));
     }
 
-    [Test]
-    public void Text_MultipleCalls_ConcatenatesText()
+    [TestCase("foobar", true)]
+    [TestCase("foo", false)]
+    [TestCase("bar", false)]
+    public void Text_MultipleCalls_ConcatenatesText(string input, bool shouldMatch)
     {
         var regex = Rejigs.Create().Text("foo").Text("bar").Build();
         
-        Assert.That("foobar", Does.Match(regex));
-        Assert.That("foo", Does.Not.Match(regex));
-        Assert.That("bar", Does.Not.Match(regex));
+        if (shouldMatch)
+            Assert.That(input, Does.Match(regex));
+        else
+            Assert.That(input, Does.Not.Match(regex));
     }
 
-    [Test]
-    public void Pattern_AddsRawRegexPattern()
+    [TestCase("123", true)]
+    [TestCase("12", false)]
+    [TestCase("abc", false)]
+    public void Pattern_AddsRawRegexPattern(string input, bool shouldMatch)
     {
         var regex = Rejigs.Create().Pattern(@"\d{3}").Build();
         
-        Assert.That("123", Does.Match(regex));
-        Assert.That("12", Does.Not.Match(regex));
-        Assert.That("abc", Does.Not.Match(regex));
+        if (shouldMatch)
+            Assert.That(input, Does.Match(regex));
+        else
+            Assert.That(input, Does.Not.Match(regex));
     }
 
-    [Test]
-    public void Pattern_CombinesWithOtherMethods()
+    [TestCase("prefix-123-suffix", true)]
+    [TestCase("prefix--suffix", false)]
+    [TestCase("prefix-abc-suffix", false)]
+    public void Pattern_CombinesWithOtherMethods(string input, bool shouldMatch)
     {
         var regex = Rejigs.Create()
                           .Text("prefix-")
@@ -91,13 +114,16 @@ public class LiteralTests
                           .Text("-suffix")
                           .Build();
 
-        Assert.That("prefix-123-suffix", Does.Match(regex));
-        Assert.That("prefix--suffix", Does.Not.Match(regex));
-        Assert.That("prefix-abc-suffix", Does.Not.Match(regex));
+        if (shouldMatch)
+            Assert.That(input, Does.Match(regex));
+        else
+            Assert.That(input, Does.Not.Match(regex));
     }
 
-    [Test]
-    public void Pattern_PreservesSpecialRegexCharacters()
+    [TestCase("word", true)]
+    [TestCase("two words", false)]
+    [TestCase("word!", false)]
+    public void Pattern_PreservesSpecialRegexCharacters(string input, bool shouldMatch)
     {
         var regex = Rejigs.Create()
                           .AtStart()
@@ -105,8 +131,9 @@ public class LiteralTests
                           .AtEnd()
                           .Build();
 
-        Assert.That("word", Does.Match(regex));
-        Assert.That("two words", Does.Not.Match(regex));
-        Assert.That("word!", Does.Not.Match(regex));
+        if (shouldMatch)
+            Assert.That(input, Does.Match(regex));
+        else
+            Assert.That(input, Does.Not.Match(regex));
     }
 }

--- a/Rejigs.Tests/QuantifiersTests.cs
+++ b/Rejigs.Tests/QuantifiersTests.cs
@@ -4,8 +4,11 @@ namespace Rejigs.Tests;
 
 public class QuantifiersTests
 {
-    [Test]
-    public void ZeroOrMore_WithText_MatchesOptionalRepeatedText()
+    [TestCase("prefix", true)]
+    [TestCase("pre-fix", true)]
+    [TestCase("pre--fix", true)]
+    [TestCase("pre**fix", false)]
+    public void ZeroOrMore_WithText_MatchesOptionalRepeatedText(string input, bool shouldMatch)
     {
         var regex = Rejigs.Create()
             .Text("pre")
@@ -13,14 +16,18 @@ public class QuantifiersTests
             .Text("fix")
             .Build();
 
-        Assert.That("prefix", Does.Match(regex));
-        Assert.That("pre-fix", Does.Match(regex));
-        Assert.That("pre--fix", Does.Match(regex));
-        Assert.That("pre**fix", Does.Not.Match(regex));
+        if (shouldMatch)
+            Assert.That(input, Does.Match(regex));
+        else
+            Assert.That(input, Does.Not.Match(regex));
     }
 
-    [Test]
-    public void ZeroOrMore_CombinedWithOtherPatterns()
+    [TestCase("AZ", true)]
+    [TestCase("A1Z", true)]
+    [TestCase("A123Z", true)]
+    [TestCase("A1B2Z", false)]
+    [TestCase("ABC", false)]
+    public void ZeroOrMore_CombinedWithOtherPatterns(string input, bool shouldMatch)
     {
         var regex = Rejigs.Create()
             .AtStart()
@@ -30,84 +37,109 @@ public class QuantifiersTests
             .AtEnd()
             .Build();
 
-        Assert.That("AZ", Does.Match(regex));
-        Assert.That("A1Z", Does.Match(regex));
-        Assert.That("A123Z", Does.Match(regex));
-        Assert.That("A1B2Z", Does.Not.Match(regex));
-        Assert.That("ABC", Does.Not.Match(regex));
+        if (shouldMatch)
+            Assert.That(input, Does.Match(regex));
+        else
+            Assert.That(input, Does.Not.Match(regex));
     }
 
-    [Test]
-    public void OneOrMore_MatchesRepeatedPattern()
+    [TestCase("a", true)]
+    [TestCase("aaa", true)]
+    [TestCase("", false)]
+    public void OneOrMore_MatchesRepeatedPattern(string input, bool shouldMatch)
     {
         var regex = Rejigs.Create().OneOrMore(r => r.Text("a")).Build();
-        Assert.That("a", Does.Match(regex));
-        Assert.That("aaa", Does.Match(regex));
-        Assert.That("", Does.Not.Match(regex));
+        
+        if (shouldMatch)
+            Assert.That(input, Does.Match(regex));
+        else
+            Assert.That(input, Does.Not.Match(regex));
     }
 
-    [Test]
-    public void Optional_MatchesOptionalPattern()
+    [TestCase("", true)]
+    [TestCase("a", true)]
+    [TestCase("aa", true)]
+    public void Optional_MatchesOptionalPattern(string input, bool shouldMatch)
     {
         var regex = Rejigs.Create().Optional(r => r.Text("a")).Build();
-        Assert.That("", Does.Match(regex));
-        Assert.That("a", Does.Match(regex));
-        Assert.That("aa", Does.Match(regex));
+        
+        if (shouldMatch)
+            Assert.That(input, Does.Match(regex));
+        else
+            Assert.That(input, Does.Not.Match(regex));
     }
 
-    [Test]
-    public void Optional_WithText_MatchesOptionalText()
+    [TestCase("colo", false)]
+    [TestCase("colou", true)]
+    [TestCase("colour", true)]
+    [TestCase("colours", true)]
+    public void Optional_WithText_MatchesOptionalText(string input, bool shouldMatch)
     {
         var regex = Rejigs.Create()
             .Text("colou")
             .Optional("r")
             .Build();
 
-        Assert.That("colo", Does.Not.Match(regex));
-        Assert.That("colou", Does.Match(regex));
-        Assert.That("colour", Does.Match(regex));
-        Assert.That("colours", Does.Match(regex));
+        if (shouldMatch)
+            Assert.That(input, Does.Match(regex));
+        else
+            Assert.That(input, Does.Not.Match(regex));
     }
 
-    [Test]
-    public void Optional_WithPattern_MatchesOptionalPattern()
+    [TestCase("fix", true)]
+    [TestCase("pre-fix", true)]
+    public void Optional_WithPattern_MatchesOptionalPattern(string input, bool shouldMatch)
     {
         var regex = Rejigs.Create()
             .Optional(r => r.Text("pre-"))
             .Text("fix")
             .Build();
 
-        Assert.That("fix", Does.Match(regex));
-        Assert.That("pre-fix", Does.Match(regex));
+        if (shouldMatch)
+            Assert.That(input, Does.Match(regex));
+        else
+            Assert.That(input, Does.Not.Match(regex));
     }
 
-    [Test]
-    public void Exactly_MatchesExactCount()
+    [TestCase("123", true)]
+    [TestCase("12", false)]
+    [TestCase("1234", false)]
+    public void Exactly_MatchesExactCount(string input, bool shouldMatch)
     {
         var regex = Rejigs.Create().AtStart().AnyDigit().Exactly(3).AtEnd().Build();
-        Assert.That("123", Does.Match(regex));
-        Assert.That("12", Does.Not.Match(regex));
-        Assert.That("1234", Does.Not.Match(regex));
+        
+        if (shouldMatch)
+            Assert.That(input, Does.Match(regex));
+        else
+            Assert.That(input, Does.Not.Match(regex));
     }
 
-    [Test]
-    public void AtLeast_MatchesMinimumCount()
+    [TestCase("12", true)]
+    [TestCase("123", true)]
+    [TestCase("1", false)]
+    public void AtLeast_MatchesMinimumCount(string input, bool shouldMatch)
     {
         var regex = Rejigs.Create().AnyDigit().AtLeast(2).Build();
-        Assert.That("12", Does.Match(regex));
-        Assert.That("123", Does.Match(regex));
-        Assert.That("1", Does.Not.Match(regex));
+        
+        if (shouldMatch)
+            Assert.That(input, Does.Match(regex));
+        else
+            Assert.That(input, Does.Not.Match(regex));
     }
 
-    [Test]
-    public void Between_MatchesRangeOfCounts()
+    [TestCase("12", true)]
+    [TestCase("123", true)]
+    [TestCase("1234", true)]
+    [TestCase("1", false)]
+    [TestCase("12345", true)]
+    public void Between_MatchesRangeOfCounts(string input, bool shouldMatch)
     {
         var regex = Rejigs.Create().AnyDigit().Between(2, 4).Build();
-        Assert.That("12", Does.Match(regex));
-        Assert.That("123", Does.Match(regex));
-        Assert.That("1234", Does.Match(regex));
-        Assert.That("1", Does.Not.Match(regex));
-        Assert.That("12345", Does.Match(regex));
+        
+        if (shouldMatch)
+            Assert.That(input, Does.Match(regex));
+        else
+            Assert.That(input, Does.Not.Match(regex));
     }
 
     [Test]
@@ -135,24 +167,32 @@ public class QuantifiersTests
         Assert.Throws<ArgumentException>(() => Rejigs.Create().AnyInRange('z', 'a'));
     }
 
-    [Test]
-    public void Quantifiers_WithUnicodeCharacters()
+    [TestCase("あ", true)]
+    [TestCase("あああ", true)]
+    [TestCase("", false)]
+    public void Quantifiers_WithUnicodeCharacters(string input, bool shouldMatch)
     {
         var regex = Rejigs.Create().OneOrMore(r => r.Text("あ")).Build();
-        Assert.That("あ", Does.Match(regex));
-        Assert.That("あああ", Does.Match(regex));
-        Assert.That("", Does.Not.Match(regex));
+        
+        if (shouldMatch)
+            Assert.That(input, Does.Match(regex));
+        else
+            Assert.That(input, Does.Not.Match(regex));
     }
 
-    [Test]
-    public void ChainedQuantifiers_NestedGroups()
+    [TestCase("", true)]
+    [TestCase("x", true)]
+    [TestCase("xx", true)]
+    [TestCase("xxx", true)]
+    public void ChainedQuantifiers_NestedGroups(string input, bool shouldMatch)
     {
         var regex = Rejigs.Create()
             .ZeroOrMore(r => r.OneOrMore(rr => rr.Text("x")))
             .Build();
-        Assert.That("", Does.Match(regex));
-        Assert.That("x", Does.Match(regex));
-        Assert.That("xx", Does.Match(regex));
-        Assert.That("xxx", Does.Match(regex));
+        
+        if (shouldMatch)
+            Assert.That(input, Does.Match(regex));
+        else
+            Assert.That(input, Does.Not.Match(regex));
     }
 }


### PR DESCRIPTION
Converted multiple test methods in the test suite to use NUnit's [TestCase] attribute for parameterized testing. This change improves test coverage, reduces code duplication, and makes it easier to add new test cases for various input scenarios.