### PR TITLE
Update LICENSE with commercial sale restriction

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -2,4 +2,26 @@ MIT License
 
 Copyright (c) 2025 OMAR
 
-Permission is hereby granted, free of charge, to any person obtaining a copy...
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+RESTRICTION ON COMMERCIAL SALE: Notwithstanding the above permissions, the
+sale of this Software as a standalone commercial product is strictly prohibited.
+This Software may be used within commercial applications and distributed as part
+of larger software packages, but may not be sold independently as a commercial
+product.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.


### PR DESCRIPTION
Added a restriction to the MIT License prohibiting the sale of the software as a standalone commercial product, while allowing use in commercial applications as part of larger packages.